### PR TITLE
[personal-blog] adds control to manage blogs 

### DIFF
--- a/personal-blog/client-react/package-lock.json
+++ b/personal-blog/client-react/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.51.5",
         "react-router-dom": "^6.23.1"
       },
       "devDependencies": {
+        "@faker-js/faker": "^8.4.1",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "@typescript-eslint/eslint-plugin": "^7.2.0",
@@ -857,6 +859,22 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
+      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3419,6 +3437,21 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.51.5",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.51.5.tgz",
+      "integrity": "sha512-J2ILT5gWx1XUIJRETiA7M19iXHlG74+6O3KApzvqB/w8S5NQR7AbU8HVZrMALdmDgWpRPYiZJl0zx8Z4L2mP6Q==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-refresh": {

--- a/personal-blog/client-react/package.json
+++ b/personal-blog/client-react/package.json
@@ -12,9 +12,11 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.51.5",
     "react-router-dom": "^6.23.1"
   },
   "devDependencies": {
+    "@faker-js/faker": "^8.4.1",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@typescript-eslint/eslint-plugin": "^7.2.0",

--- a/personal-blog/client-react/src/components/BlogRow.tsx
+++ b/personal-blog/client-react/src/components/BlogRow.tsx
@@ -1,0 +1,30 @@
+import { Link } from "react-router-dom";
+import { Blog } from "../interfaces/Blog";
+
+interface BlogRowProps {
+  blog: Blog;
+  index: number;
+}
+
+export default function BlogRow({ blog, index }: BlogRowProps) {
+  return (
+    <tr className="even:bg-neutral-100">
+      <td>{index}</td>
+      <td>{blog.title}</td>
+      <td className="flex justify-center gap-2 ">
+        <Link
+          to={"/"}
+          className="text-blue-500 hover:text-blue-700 hover:underline"
+        >
+          Ver
+        </Link>
+        <Link
+          to={"/edit/" + blog.id}
+          className="text-blue-500 hover:text-blue-700 hover:underline"
+        >
+          Editar
+        </Link>
+      </td>
+    </tr>
+  );
+}

--- a/personal-blog/client-react/src/interfaces/Blog.ts
+++ b/personal-blog/client-react/src/interfaces/Blog.ts
@@ -1,0 +1,8 @@
+export interface Blog {
+  title: string;
+  content: string;
+  image: string;
+  createdAt: string;
+  updatedAt: string;
+  id: string;
+}

--- a/personal-blog/client-react/src/main.tsx
+++ b/personal-blog/client-react/src/main.tsx
@@ -5,12 +5,14 @@ import AdminPage from "./pages/AdminPage.tsx";
 import HomePage from "./pages/HomePage.tsx";
 import PostPage from "./pages/PostPage.tsx";
 import "./index.css";
+import NewBlogPage from "./pages/NewBlogPage.tsx";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<HomePage />} />
+        <Route path="/admin/new" element={<NewBlogPage />} />
         <Route path="/post/:postId" element={<PostPage />} />
         <Route path="/admin" element={<AdminPage />} />
         {/* Redirects home, all urls that do not match */}

--- a/personal-blog/client-react/src/pages/AdminPage.tsx
+++ b/personal-blog/client-react/src/pages/AdminPage.tsx
@@ -1,10 +1,75 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import BlogRow from "../components/BlogRow";
+import { Blog } from "../interfaces/Blog";
+
 export default function AdminPage() {
+  const [blogs, setBlogs] = useState([]);
+
+  useEffect(() => {
+    fetch("http://localhost:3000/blogs")
+      .then((res) => res.json())
+      .then((data) => setBlogs(data));
+  }, []);
+
   return (
     <>
-      <p>Admin page - Should be used to create new post</p>
-      <p>
-        Theres not planned include authentication, so this URL is a secret! XD
-      </p>
+      <div className="h-dvh">
+        <div className="max-w-4xl px-3 py-5 mx-auto">
+          <div className="text-center">
+            <p className="text-4xl font-semibold">Panel de control</p>
+            <p className="mt-3 text-lg text-rose-600">
+              Mantén este URL confidencial.
+            </p>
+          </div>
+          <div className="flex justify-end w-full">
+            <Link
+              to={"/admin/new"}
+              className="px-5 py-4 mt-5 font-semibold text-center text-white transition duration-300 bg-green-500 border border-green-600 hover:shadow-xl"
+            >
+              NUEVO BLOG +
+            </Link>
+          </div>
+
+          {}
+
+          {blogs && blogs.length >= 1 ? (
+            <table className="w-full mx-auto mt-5 text-center">
+              <thead>
+                <tr className="text-white bg-neutral-600">
+                  <th className="">#</th>
+                  <th className="">Titulo</th>
+                  <th className="">Opciones</th>
+                </tr>
+              </thead>
+              <tbody>
+                {blogs.map((blog: Blog, index: number) => {
+                  return <BlogRow key={blog.id} index={index} blog={blog} />;
+                })}
+              </tbody>
+            </table>
+          ) : (
+            <div className="flex flex-col items-center justify-center w-full mt-5 border border-dashed border-neutral-600 h-96 bg-neutral-50">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="size-6"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z"
+                />
+              </svg>
+
+              <p className="font-semibold">No hay blogs en el sistema.</p>
+            </div>
+          )}
+        </div>
+      </div>
     </>
   );
 }

--- a/personal-blog/client-react/src/pages/NewBlogPage.tsx
+++ b/personal-blog/client-react/src/pages/NewBlogPage.tsx
@@ -1,0 +1,118 @@
+import { SubmitHandler, useForm } from "react-hook-form";
+import { Link, useNavigate } from "react-router-dom";
+import { faker } from "@faker-js/faker";
+import { useEffect, useState } from "react";
+
+type Inputs = {
+  title: string;
+  content: string;
+  image: string;
+};
+
+export default function NewBlogPage() {
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<Inputs>();
+
+  const [imageSrc, setImageSrc] = useState("");
+
+  const navigate = useNavigate();
+  const onSubmit: SubmitHandler<Inputs> = async (form) => {
+    try {
+      const formBody = Object.entries(form)
+        .map(
+          ([key, value]) =>
+            encodeURIComponent(key) + "=" + encodeURIComponent(value)
+        )
+        .join("&");
+
+      const request = await fetch("http://localhost:3000/blogs", {
+        method: "POST",
+        body: formBody,
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        },
+      });
+
+      if (!request.ok) return;
+
+      return navigate("/admin", { replace: true });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const watchedImage = watch("image");
+
+  useEffect(() => {
+    setImageSrc(watchedImage);
+  }, [watchedImage]);
+
+  return (
+    <>
+      <div className="h-dvh">
+        <div className="max-w-4xl px-3 py-5 mx-auto">
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="flex flex-col gap-2"
+          >
+            <Link
+              to={"/admin"}
+              className="text-blue-500 hover:text-blue-700 hover:underline w-fit"
+            >
+              Volver
+            </Link>
+            <label className="font-bold" htmlFor="title">
+              Titulo
+            </label>
+            <input
+              className="py-1 border ps-2"
+              defaultValue={faker.lorem.sentence(5)}
+              {...register("title", { required: true })}
+            />
+
+            {errors.title && (
+              <span className="text-red-500">Este campo es necesario</span>
+            )}
+
+            <label className="font-bold" htmlFor="content">
+              Contenido
+            </label>
+            <input
+              className="py-1 border ps-2"
+              defaultValue={faker.lorem.sentence()}
+              {...register("content", { required: true })}
+            />
+
+            {errors.content && (
+              <span className="text-red-500">Este campo es necesario</span>
+            )}
+
+            <label className="font-bold" htmlFor="image">
+              Imagen
+            </label>
+            <input
+              className="py-1 border ps-2"
+              defaultValue={faker.image.url()}
+              {...register("image", { required: true })}
+            />
+
+            {errors.image && (
+              <span className="text-red-500">Este campo es necesario</span>
+            )}
+
+            <img src={imageSrc} />
+
+            <input
+              className="px-5 py-4 mt-5 font-semibold text-white transition duration-300 bg-black border border-gray-400 hover:bg-green-500 hover:border-green-600 hover:shadow-xl hover:cursor-pointer"
+              type="submit"
+            />
+          </form>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Se añadio de forma basica una forma de gestionar los blogs desde el lado del cliente, esta interfaz permite visualizar, contabilizar los blogs. Ademas de crear nuevos blogs, los inputs tienen validación.

Para esto se añadio el package `faker` `react-hook-form`

Tareas para otra PR:
- Editar blogs
- Eliminar blogs
- Refactorizar mucho 🐳


Similar a: #10 

